### PR TITLE
Add rspec & linter runs

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -1,0 +1,26 @@
+env:
+  CI: true
+  RAILS_ENV: test
+
+name: Rubocop
+on:
+  push:
+
+jobs:
+  linter-run:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.1'
+
+      - name: Bundle config & install
+        run: bundle install
+
+      - name: Rubocop linter
+        run: bundle exec rubocop
+

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -1,0 +1,26 @@
+env:
+  CI: true
+  RAILS_ENV: test
+
+name: RSpec Suite
+on:
+  push:
+
+jobs:
+  rspec-run:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.1'
+
+      - name: Bundle config & install
+        run: bundle install
+
+      - name: Rspec suite
+        run: bundle exec rspec --format progress
+


### PR DESCRIPTION
we don't have a `.ruby-version` specified in this repo, so I just went with `3.1` for rspec runs - this can be changed if we want.